### PR TITLE
Edits for stage2/03-screenly/01-run.sh after updating pi-gen to latest

### DIFF
--- a/stage2/03-screenly/01-run.sh
+++ b/stage2/03-screenly/01-run.sh
@@ -1,6 +1,8 @@
 #!/bin/bash -e
 
 on_chroot << EOF
+  c_rehash /etc/ssl/certs
+
   curl -s https://bootstrap.pypa.io/get-pip.py | python
 
   # Fetch wait-for-it
@@ -18,7 +20,7 @@ on_chroot << EOF
   cd ansible
   HOME=/home/pi MANAGE_NETWORK=true ansible-playbook site.yml --skip-tags enable-ssl,disable-nginx,touches_boot_partition
   chown -R pi:pi /home/pi
-  rm /home/pi/.screenly/initialized
+  rm -f /home/pi/.screenly/initialized
 
   apt-get autoclean
   apt-get clean


### PR DESCRIPTION
Necessary edits for successful image creation.

PS. I also change main mirror in `stage0/00-configure-apt/files/sources.list` cause I was getting errors about dropped connection in different points.
```
diff --git a/stage0/00-configure-apt/files/sources.list b/stage0/00-configure-apt/files/sources.list
index 61820ac..63a1db8 100644
--- a/stage0/00-configure-apt/files/sources.list
+++ b/stage0/00-configure-apt/files/sources.list
@@ -1,3 +1,3 @@
-deb http://raspbian.raspberrypi.org/raspbian/ buster main contrib non-free rpi
+deb http://mirror.yandex.ru/mirrors/raspbian/raspbian/ buster main contrib non-free rpi
 # Uncomment line below then 'apt-get update' to enable 'apt-get source'
 #deb-src http://raspbian.raspberrypi.org/raspbian/ buster main contrib non-free rpi
```

Anyway in the end I have fully working image.
